### PR TITLE
Update mini/full_config.md

### DIFF
--- a/mini/full_config.md
+++ b/mini/full_config.md
@@ -3,7 +3,7 @@
   - [yamlファイルの各キーの説明](#yamlファイルの各キーの説明)
     - [`application`](#application)
     - [`application.title`, `application.process`, `application.url`](#applicationtitle-applicationprocess-applicationurl)
-    - [`application.os`](#applicationos)
+    - [`application.os_variant`](#applicationos_variant)
     - [`application.keymaps`](#applicationkeymaps)
     - [`application.keymaps.layer`](#applicationkeymapslayer)
     - [`application.keymaps.layer.id`](#applicationkeymapslayerid)
@@ -65,9 +65,9 @@
 
 目的のウィンドウのタイトルやプロセス名を知りたい場合、コンパニオンアプリ起動中にタスクトレイアイコンをクリックすると直前にアクティブだったウィンドウの情報が表示されます。
 
-#### `application.os`
+#### `application.os_variant`
 
-(省略可能) 設定値と接続先のOSが一致するときのみ、各キーマップやコンボ等が有効になります。`title`, `process`, `url` と合わせて設定した場合は、AND条件として評価されます。
+(省略可能) 設定値と接続先のOSが一致するときのみ、各キーマップやコンボ等が有効になります (`Any`, `Linux`, `Windows`, `macOS` or `iOS`)。`title`, `process`, `url` と合わせて設定した場合は、AND条件として評価されます。
 
 #### `application.keymaps`
 


### PR DESCRIPTION
OS ごとに keymap を切り替えたいのですが、`application.os` を利用できませんでした。もしかしたらドキュメントで案内されている名前が違っているのかもと思い PR を作成しました。

以下の JSON Schema によると `application.os` ではなく `application.os_variant` が正しいように見えました。実際に [Keyboard Quantizer Config Generator](https://sekigon-gonnoc.github.io/keyboard-quantizer-config-generator/) でも `application.os` は認識されず、代わりに `application.oa_variant` が認識されているようでした。

https://github.com/sekigon-gonnoc/keyboard-quantizer-config-generator/blob/4363666bc19c8a3e4a981f9798ee2285cbdae5a5/src/schema/yaml.schema.json#L36C14-L44
